### PR TITLE
Add Pinata IPFS support, reuse task-runner classes

### DIFF
--- a/clients/base.go
+++ b/clients/base.go
@@ -1,0 +1,132 @@
+package clients
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+)
+
+var UserAgent string
+
+type BaseClient struct {
+	*http.Client
+	BaseUrl     string
+	BaseHeaders map[string]string
+}
+
+type Request struct {
+	Method, URL string
+	Body        io.Reader
+	ContentType string
+	Headers     map[string]string
+}
+
+type HTTPStatusError struct {
+	Status int
+	Body   string
+}
+
+func (e *HTTPStatusError) Error() string {
+	return fmt.Sprintf("http status %d %s: %q", e.Status, http.StatusText(e.Status), e.Body)
+}
+
+func (c *BaseClient) DoRequest(ctx context.Context, r Request, output interface{}) error {
+	req, err := c.newRequest(ctx, r)
+	if err != nil {
+		return err
+	}
+
+	client := http.DefaultClient
+	if c.Client != nil {
+		client = c.Client
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if (r.Method == "GET" && resp.StatusCode != http.StatusOK) || (resp.StatusCode >= 300) {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		return &HTTPStatusError{resp.StatusCode, string(body)}
+	}
+	if output == nil {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(output)
+}
+
+func (c *BaseClient) newRequest(ctx context.Context, r Request) (*http.Request, error) {
+	url := c.BaseUrl + r.URL
+	req, err := http.NewRequestWithContext(ctx, r.Method, url, r.Body)
+	if err != nil {
+		return nil, err
+	}
+	if UserAgent != "" {
+		req.Header.Set("User-Agent", UserAgent)
+	}
+	for key, value := range c.BaseHeaders {
+		req.Header.Set(key, value)
+	}
+	for key, value := range r.Headers {
+		req.Header.Set(key, value)
+	}
+	if r.ContentType != "" {
+		req.Header.Set("Content-Type", r.ContentType)
+	}
+	return req, nil
+}
+
+type part struct {
+	name            string
+	filename        string
+	fileContentType string
+	data            io.Reader
+}
+
+func multipartBody(parts []part) (body io.ReadCloser, contentType string) {
+	body, pipe := io.Pipe()
+	mw := multipart.NewWriter(pipe)
+	go func() (err error) {
+		defer func() { pipe.CloseWithError(err) }()
+		for _, p := range parts {
+			err = writePart(mw, p.name, p.filename, p.fileContentType, p.data)
+			if err != nil {
+				return
+			}
+		}
+		err = mw.Close()
+		return
+	}()
+	return body, mw.FormDataContentType()
+}
+
+func writePart(mw *multipart.Writer, name, filename, contentType string, data io.Reader) error {
+	partw, err := mw.CreatePart(mimeHeader(name, filename, contentType))
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(partw, data)
+	return err
+}
+
+func mimeHeader(name, filename, contentType string) textproto.MIMEHeader {
+	contentDisposition := fmt.Sprintf(`form-data; name=%q`, name)
+	if filename != "" {
+		contentDisposition += fmt.Sprintf(`; filename=%q`, filename)
+	}
+	mime := textproto.MIMEHeader{}
+	mime.Set("Content-Disposition", contentDisposition)
+	if contentType != "" {
+		mime.Set("Content-Type", contentType)
+	}
+	return mime
+}

--- a/clients/ipfs.go
+++ b/clients/ipfs.go
@@ -1,0 +1,134 @@
+package clients
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+const (
+	pinataBaseUrl = "https://api.pinata.cloud"
+	jsonMimeType  = "application/json"
+	pinataOptions = `{"cidVersion":1}`
+)
+
+type PinInfo struct {
+	ID          string `json:"id"`
+	IPFSPinHash string `json:"ipfs_pin_hash"`
+	Size        int64  `json:"size"`
+	Metadata    struct {
+		Name      string            `json:"name"`
+		KeyValues map[string]string `json:"keyvalues"`
+	} `json:"metadata"`
+}
+
+type PinList struct {
+	Count int64     `json:"count"`
+	Pins  []PinInfo `json:"rows"`
+}
+
+type IPFS interface {
+	PinContent(ctx context.Context, name, contentType string, data io.Reader) (cid string, metadata interface{}, err error)
+	Unpin(ctx context.Context, cid string) error
+	List(ctx context.Context, pageSize, pageOffset int) (*PinList, int, error)
+}
+
+func NewPinataClientJWT(jwt string, filesMetadata map[string]string) IPFS {
+	return &pinataClient{
+		BaseClient: BaseClient{
+			BaseUrl: pinataBaseUrl,
+			BaseHeaders: map[string]string{
+				"Authorization": "Bearer " + jwt,
+			},
+		},
+		filesMetadata: marshalFilesMetadata(filesMetadata),
+	}
+}
+
+func NewPinataClientAPIKey(apiKey, apiSecret string, filesMetadata map[string]string) IPFS {
+	return &pinataClient{
+		BaseClient: BaseClient{
+			BaseUrl: pinataBaseUrl,
+			BaseHeaders: map[string]string{
+				"pinata_api_key":        apiKey,
+				"pinata_secret_api_key": apiSecret,
+			},
+		},
+		filesMetadata: marshalFilesMetadata(filesMetadata),
+	}
+}
+
+type pinataClient struct {
+	BaseClient
+	filesMetadata []byte
+}
+
+type uploadResponse struct {
+	IPFSHash    string    `json:"ipfsHash"`
+	PinSize     int64     `json:"pinSize"`
+	Timestamp   time.Time `json:"timestamp"`
+	IsDuplicate bool      `json:"isDuplicate"`
+}
+
+func (p *pinataClient) PinContent(ctx context.Context, filename, fileContentType string, data io.Reader) (string, interface{}, error) {
+	parts := []part{
+		{"file", filename, fileContentType, data},
+		{"pinataOptions", "", jsonMimeType, strings.NewReader(pinataOptions)},
+	}
+	if p.filesMetadata != nil {
+		parts = append(parts, part{"pinataMetadata", "", jsonMimeType, bytes.NewReader(p.filesMetadata)})
+	}
+	body, contentType := multipartBody(parts)
+	defer body.Close()
+
+	var res *uploadResponse
+	err := p.DoRequest(ctx, Request{
+		Method:      "POST",
+		URL:         "/pinning/pinFileToIPFS",
+		Body:        body,
+		ContentType: contentType,
+	}, &res)
+	if err != nil {
+		return "", nil, err
+	}
+	return res.IPFSHash, res, nil
+}
+
+func (p *pinataClient) Unpin(ctx context.Context, cid string) error {
+	return p.DoRequest(ctx, Request{
+		Method: "DELETE",
+		URL:    "/pinning/unpin/" + cid,
+	}, nil)
+}
+
+func (p *pinataClient) List(ctx context.Context, pageSize, pageOffset int) (pl *PinList, next int, err error) {
+	err = p.DoRequest(ctx, Request{
+		Method: "GET",
+		URL:    fmt.Sprintf("/data/pinList?status=pinned&pageLimit=%d&pageOffset=%d", pageSize, pageOffset),
+	}, &pl)
+	if err != nil {
+		return nil, -1, err
+	}
+
+	next = -1
+	if len(pl.Pins) >= pageSize {
+		next = pageOffset + len(pl.Pins)
+	}
+	return pl, next, err
+}
+
+func marshalFilesMetadata(keyvalues map[string]string) []byte {
+	if len(keyvalues) == 0 {
+		return nil
+	}
+	metadata := map[string]interface{}{"keyvalues": keyvalues}
+	bytes, err := json.Marshal(metadata)
+	if err != nil {
+		return nil
+	}
+	return bytes
+}

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -62,10 +62,11 @@ type FileInfoReader struct {
 }
 
 var AvailableDrivers = []OSDriver{
-	&S3OS{},
 	&FSOS{},
 	&GsOS{},
+	&IpfsOS{},
 	&MemoryOS{},
+	&S3OS{},
 }
 
 type PageInfo interface {
@@ -232,6 +233,15 @@ func ParseOSURL(input string, useFullAPI bool) (OSDriver, error) {
 			return NewS3Driver(u.Host, bucket, u.User.Username(), pw, keyPrefix, useFullAPI)
 		} else {
 			return NewCustomS3Driver(u.Host, bucket, u.User.Username(), pw, keyPrefix, useFullAPI, isSSL)
+		}
+	}
+	if u.Scheme == "ipfs" {
+		// make it explicit that it's Pinata API, not IPFS node
+		if u.Host == "pinata.cloud" {
+			password, _ := u.User.Password()
+			return NewIpfsDriver(u.User.Username(), password), nil
+		} else {
+			return nil, fmt.Errorf("unsupported IPFS provider: %s", u.Host)
 		}
 	}
 	if u.Scheme == "gs" {

--- a/drivers/drivers_test.go
+++ b/drivers/drivers_test.go
@@ -49,6 +49,16 @@ func TestFsPath(t *testing.T) {
 	testPath("tmp/test/stream.ts")
 }
 
+func TestIpfsUrls(t *testing.T) {
+	assert := assert.New(t)
+	os, err := ParseOSURL("ipfs://pinata.cloud", true)
+	assert.Equal(nil, err)
+	_, isfs := os.(*IpfsOS)
+	assert.Equal(true, isfs)
+	_, err = ParseOSURL("ipfs://", true)
+	assert.NotNil(err)
+}
+
 func TestCustomS3URL(t *testing.T) {
 	assert := assert.New(t)
 	os, err := ParseOSURL("s3+http://user:password@example.com:9000/bucket-name", true)

--- a/drivers/fs_test.go
+++ b/drivers/fs_test.go
@@ -28,7 +28,7 @@ func TestFsOS(t *testing.T) {
 	u, err := url.Parse("/tmp/")
 	assert.NoError((err))
 	storage := NewFSDriver(u)
-	sess := storage.NewSession(("driver-test")).(*FSSession)
+	sess := storage.NewSession("driver-test").(*FSSession)
 	path, err := sess.SaveData(context.TODO(), "name1/1.ts", bytes.NewReader(rndData), nil, 0)
 	assert.NoError(err)
 	defer os.Remove(path)

--- a/drivers/ipfs.go
+++ b/drivers/ipfs.go
@@ -1,0 +1,117 @@
+package drivers
+
+import (
+	"context"
+	"github.com/livepeer/go-tools/clients"
+	"io"
+	"net/http"
+	"path"
+	"sync"
+	"time"
+)
+
+type IpfsOS struct {
+	key    string
+	secret string
+}
+
+type IpfsSession struct {
+	os       *IpfsOS
+	filename string
+	ended    bool
+	client   clients.IPFS
+	dCache   map[string]*dataCache
+	dLock    sync.RWMutex
+}
+
+func NewIpfsDriver(key, secret string) *IpfsOS {
+	return &IpfsOS{key: key, secret: secret}
+}
+
+func (ostore *IpfsOS) NewSession(filename string) OSSession {
+	if filename != "" {
+		panic("File names are not supported by Pinata IPFS driver")
+	}
+	var client clients.IPFS
+	if ostore.key != "" {
+		client = clients.NewPinataClientAPIKey(ostore.key, ostore.secret, map[string]string{})
+	} else {
+		client = clients.NewPinataClientJWT(ostore.secret, map[string]string{})
+	}
+	session := &IpfsSession{
+		os:       ostore,
+		filename: filename,
+		dCache:   make(map[string]*dataCache),
+		dLock:    sync.RWMutex{},
+		client:   client,
+	}
+	return session
+}
+
+func (ostore *IpfsOS) UriSchemes() []string {
+	return []string{"ipfs://pinata.cloud"}
+}
+
+func (ostore *IpfsOS) Description() string {
+	return "Pinata cloud IPFS driver."
+}
+
+func (ostore *IpfsSession) OS() OSDriver {
+	return ostore.os
+}
+
+func (ostore *IpfsSession) EndSession() {
+	// no op
+}
+
+func (ostore *IpfsSession) ListFiles(ctx context.Context, dir, delim string) (PageInfo, error) {
+	panic("Listing is not supported by Pinata IPFS driver")
+}
+
+func (ostore *IpfsSession) ReadData(ctx context.Context, name string) (*FileInfoReader, error) {
+	fullPath := path.Join(ostore.filename, name)
+	// just get the file through Pinata HTTP gateway
+	resp, err := http.Get("https://gateway.pinata.cloud/ipfs/" + fullPath)
+	if err != nil {
+		return nil, err
+	}
+	res := &FileInfoReader{
+		FileInfo: FileInfo{
+			Name: name,
+			Size: nil,
+		},
+		Body: resp.Body,
+	}
+	return res, nil
+}
+
+func (ostore *IpfsSession) IsExternal() bool {
+	return false
+}
+
+func (ostore *IpfsSession) IsOwn(url string) bool {
+	return true
+}
+
+func (ostore *IpfsSession) GetInfo() *OSInfo {
+	return nil
+}
+
+func (ostore *IpfsSession) SaveData(ctx context.Context, name string, data io.Reader, meta map[string]string, timeout time.Duration) (string, error) {
+	// concatenate filename with name argument to get full filename, both may be empty
+	fullPath := ostore.getAbsolutePath(name)
+	if fullPath == "" {
+		// pinata requires name to be set
+		fullPath = "data.bin"
+	}
+	cid, _, err := ostore.client.PinContent(ctx, fullPath, "", data)
+	return cid, err
+}
+
+func (ostore *IpfsSession) getAbsolutePath(name string) string {
+	resPath := path.Clean(ostore.filename + "/" + name)
+	if resPath == "/" {
+		return ""
+	}
+	return resPath
+}

--- a/drivers/ipfs_test.go
+++ b/drivers/ipfs_test.go
@@ -1,0 +1,31 @@
+package drivers
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestIpfsOS(t *testing.T) {
+	pinataKey := os.Getenv("PINATA_KEY")
+	pinataSecret := os.Getenv("PINATA_SECRET")
+	if pinataSecret == "" {
+		return
+	}
+	// create random data
+	rndData := make([]byte, 1024*10)
+	rand.Read(rndData)
+	assert := assert.New(t)
+	storage := NewIpfsDriver(pinataKey, pinataSecret)
+	sess := storage.NewSession("").(*IpfsSession)
+	cid, err := sess.SaveData(context.TODO(), "", bytes.NewReader(rndData), nil, 0)
+	assert.NoError(err)
+	ipfsInfo, err := sess.ReadData(context.TODO(), cid)
+	assert.NoError(err)
+	ipfsData := new(bytes.Buffer)
+	ipfsData.ReadFrom(ipfsInfo.Body)
+	assert.Equal(rndData, ipfsData.Bytes())
+}


### PR DESCRIPTION
Adds IPFS support through Pinata API (#3). I reused `base.go` and `ipfs.go` from [task-runner](https://github.com/livepeer/task-runner) with insignificant modifications. TODO: remove these files from `task-runner`, as `go-tools` is already a dependency.
