### PR TITLE
drivers: Fix behavior of ReadData with a session key

### DIFF
--- a/drivers/s3.go
+++ b/drivers/s3.go
@@ -272,6 +272,7 @@ func (os *s3Session) ListFiles(ctx context.Context, prefix, delim string) (PageI
 		params := &s3.ListObjectsInput{
 			Bucket: bucket,
 		}
+		prefix = path.Join(os.key, prefix)
 		if prefix != "" {
 			params.Prefix = aws.String(prefix)
 		}
@@ -296,14 +297,10 @@ func (os *s3Session) ReadData(ctx context.Context, name string) (*FileInfoReader
 	if os.s3svc == nil {
 		return nil, fmt.Errorf("Not implemented")
 	}
-	key := name
-	// if name is not specified, assume that this session already created with specific key
-	if key == "" {
-		key = os.key
-	}
+	keyname := aws.String(path.Join(os.key, name))
 	params := &s3.GetObjectInput{
 		Bucket: aws.String(os.bucket),
-		Key:    aws.String(key),
+		Key:    keyname,
 	}
 	resp, err := os.s3svc.GetObjectWithContext(ctx, params)
 	if err != nil {


### PR DESCRIPTION
The `ReadData` function from the S3 driver was resolving files in a different
way when there was a key present. Instead of treating it as a prefix, it only used
it if no key was provided. So if you write a file you can never read it unless you know
what's the internal `key` used in the OS driver.

Also fixed list which was completely ignoring the key. Use it as a prefix as well.