### PR TITLE
Handle gracefully S3 objects without metadata

### DIFF
--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -96,9 +96,8 @@ type S3OSInfo struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-//
-//OSInfo needed to negotiate storages that will be used.
-//It carries info needed to write to the storage.
+// OSInfo needed to negotiate storages that will be used.
+// It carries info needed to write to the storage.
 type OSInfo struct {
 	// Storage type: direct, s3, ipfs.
 	StorageType          OSInfo_StorageType `protobuf:"varint,1,opt,name=storageType,proto3,enum=net.OSInfo_StorageType" json:"storageType,omitempty"`

--- a/drivers/s3.go
+++ b/drivers/s3.go
@@ -40,10 +40,9 @@ const (
 	uploaderPartSize = 63 * 1024 * 1024
 )
 
-/* S3OS S3 backed object storage driver. For own storage access key and access key secret
-   should be specified. To give to other nodes access to own S3 storage so called 'POST' policy
-   is created. This policy is valid for S3_POLICY_EXPIRE_IN_HOURS hours.
-*/
+// S3OS S3 backed object storage driver. For own storage access key and access key secret
+// should be specified. To give to other nodes access to own S3 storage so called 'POST' policy
+// is created. This policy is valid for S3_POLICY_EXPIRE_IN_HOURS hours.
 type S3OS struct {
 	host               string
 	region             string
@@ -315,8 +314,12 @@ func (os *s3Session) ReadData(ctx context.Context, name string) (*FileInfoReader
 	res := &FileInfoReader{
 		Body: resp.Body,
 	}
-	res.LastModified = *resp.LastModified
-	res.ETag = *resp.ETag
+	if resp.LastModified != nil {
+		res.LastModified = *resp.LastModified
+	}
+	if resp.ETag != nil {
+		res.ETag = *resp.ETag
+	}
 	res.Name = name
 	res.Size = resp.ContentLength
 	if len(resp.Metadata) > 0 {

--- a/drivers/s3_test.go
+++ b/drivers/s3_test.go
@@ -93,3 +93,25 @@ func TestMinioS3Upload(t *testing.T) {
 		fmt.Println("No S3 credentials, test skipped")
 	}
 }
+
+func TestStorjS3Read(t *testing.T) {
+	s3key := os.Getenv("STORJ_S3_KEY")
+	s3secret := os.Getenv("STORJ_S3_SECRET")
+	s3bucket := os.Getenv("STORJ_S3_BUCKET")
+	s3Path := os.Getenv("STORJ_S3_PATH")
+	assert := assert.New(t)
+	if s3key != "" && s3secret != "" && s3bucket != "" && s3Path != "" {
+		fullUrl := fmt.Sprintf("s3+https://%s:%s@gateway.storjshare.io/%s", s3key, s3secret, s3bucket)
+		os, err := ParseOSURL(fullUrl, true)
+		assert.NoError(err)
+		session := os.NewSession("")
+		data, err := session.ReadData(context.Background(), s3Path)
+		assert.NoError(err)
+		osBuf := new(bytes.Buffer)
+		osBuf.ReadFrom(data.Body)
+		osData := osBuf.Bytes()
+		assert.True(len(osData) > 0)
+	} else {
+		fmt.Println("No S3 credentials, test skipped")
+	}
+}


### PR DESCRIPTION
fix https://github.com/livepeer/go-tools/issues/9

The initial problem was that Storj buckets don't contain ETags, which causes `panic` while using [Transcode API](https://www.notion.so/livepeer/Transcode-API-Doc-b36b0c8c1a794e3b8edbf6a4fb1d49f5). 

I added a unit test, but I'm somewhere on the fence if we should have it or not. @cyberj0g if you have any opinion, let me know. For the context, it does not make sense to have the whole "upload' test for Storj, because files added with AWS SDK to Storj actually includes ETag, only the files which are uploaded using the native Storj CLI (`uplink`) lack ETags.