### PR TITLE
Fix base64UrlToBase64

### DIFF
--- a/drivers/w3s.go
+++ b/drivers/w3s.go
@@ -365,7 +365,7 @@ func runWithCredentials(cmd *exec.Cmd, proof string) ([]byte, error) {
 }
 
 func base64UrlToBase64(proof string) (string, error) {
-	ucanProofByte, err := base64.URLEncoding.DecodeString(proof)
+	ucanProofByte, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(proof)
 	if err != nil {
 		return "", err
 	}

--- a/drivers/w3s_test.go
+++ b/drivers/w3s_test.go
@@ -86,3 +86,38 @@ func randFiledata() []byte {
 	rand.Read(rndData)
 	return rndData
 }
+
+func TestBase64UrlToBase64(t *testing.T) {
+	require := require2.New(t)
+
+	tests := []struct {
+		name string
+		arg  string
+		exp  string
+	}{
+		{
+			name: "standard text",
+			arg:  "c29tZSB0ZXh0",
+			exp:  "c29tZSB0ZXh0",
+		},
+		{
+			name: "binary no padding",
+			arg:  "eSK_-HCmI596rRX4xY",
+			exp:  "eSK/+HCmI596rRX4xQ==",
+		},
+		{
+			name: "binary with padding",
+			arg:  "_-HCmI596rRX4xY",
+			exp:  "/+HCmI596rRX4xY=",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := base64UrlToBase64(tc.arg)
+			require.NoError(err)
+			require.Equal(tc.exp, res)
+		})
+	}
+}


### PR DESCRIPTION
Base64url format by default does not use any padding, which needs to be explicitly specified in Golang.

fix https://github.com/livepeer/catalyst/issues/401