### PR TITLE
Add presign function to S3 driver

### DIFF
--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -141,6 +141,8 @@ type OSSession interface {
 	DeleteFile(ctx context.Context, name string) error
 
 	ReadData(ctx context.Context, name string) (*FileInfoReader, error)
+
+	Presign(bucket, key string, expire time.Duration) (string, error)
 }
 
 type OSDriverDescr struct {

--- a/drivers/fs.go
+++ b/drivers/fs.go
@@ -152,6 +152,10 @@ func (ostore *FSSession) ReadData(ctx context.Context, name string) (*FileInfoRe
 	return res, nil
 }
 
+func (ostore *FSSession) Presign(bucket, key string, expire time.Duration) (string, error) {
+	return "", ErrNotSupported
+}
+
 func (ostore *FSSession) IsExternal() bool {
 	return false
 }

--- a/drivers/gs.go
+++ b/drivers/gs.go
@@ -343,6 +343,10 @@ func (os *gsSession) ReadData(ctx context.Context, name string) (*FileInfoReader
 	return res, nil
 }
 
+func (os *gsSession) Presign(bucket, key string, expire time.Duration) (string, error) {
+	return "", ErrNotSupported
+}
+
 func gsGetFields(sess *s3Session) map[string]string {
 	return map[string]string{
 		"GoogleAccessId": sess.credential,

--- a/drivers/ipfs.go
+++ b/drivers/ipfs.go
@@ -99,6 +99,10 @@ func (session *IpfsSession) ReadData(ctx context.Context, name string) (*FileInf
 	return res, nil
 }
 
+func (session *IpfsSession) Presign(bucket, key string, expire time.Duration) (string, error) {
+	return "", ErrNotSupported
+}
+
 func (session *IpfsSession) IsExternal() bool {
 	return false
 }

--- a/drivers/local.go
+++ b/drivers/local.go
@@ -192,6 +192,10 @@ func (ostore *MemorySession) GetData(name string) []byte {
 	return nil
 }
 
+func (ostore *MemorySession) Presign(bucket, key string, expire time.Duration) (string, error) {
+	return "", ErrNotSupported
+}
+
 func (ostore *MemorySession) IsExternal() bool {
 	return false
 }

--- a/drivers/s3.go
+++ b/drivers/s3.go
@@ -489,6 +489,14 @@ func (os *s3Session) IsOwn(url string) bool {
 	return strings.HasPrefix(url, os.host)
 }
 
+func (os *s3Session) Presign(bucket, key string, expire time.Duration) (string, error) {
+	req, _ := os.s3svc.GetObjectRequest(&s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	return req.Presign(expire)
+}
+
 func makeHmac(key []byte, data []byte) []byte {
 	hash := hmac.New(sha256.New, key)
 	hash.Write(data)

--- a/drivers/session_mock.go
+++ b/drivers/session_mock.go
@@ -73,3 +73,7 @@ func (s *MockOSSession) ReadData(ctx context.Context, name string) (*FileInfoRea
 func (s *MockOSSession) OS() OSDriver {
 	return nil
 }
+
+func (s *MockOSSession) Presign(bucket, key string, expire time.Duration) (string, error) {
+	return "", ErrNotSupported
+}

--- a/drivers/w3s.go
+++ b/drivers/w3s.go
@@ -104,6 +104,10 @@ func (session *W3sSession) ReadData(ctx context.Context, name string) (*FileInfo
 	return nil, ErrNotSupported
 }
 
+func (session *W3sSession) Presign(bucket, key string, expire time.Duration) (string, error) {
+	return "", ErrNotSupported
+}
+
 func (session *W3sSession) IsExternal() bool {
 	return false
 }


### PR DESCRIPTION
We will be using this in catalyst-api to generate temporary object URLs for probing and sending to mediaconvert.