### PR TITLE
Modify presign signature to match existing functions in the OS interface

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     name: Run tests defined for the project
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -142,7 +142,7 @@ type OSSession interface {
 
 	ReadData(ctx context.Context, name string) (*FileInfoReader, error)
 
-	Presign(bucket, key string, expire time.Duration) (string, error)
+	Presign(name string, expire time.Duration) (string, error)
 }
 
 type OSDriverDescr struct {

--- a/drivers/fs.go
+++ b/drivers/fs.go
@@ -152,7 +152,7 @@ func (ostore *FSSession) ReadData(ctx context.Context, name string) (*FileInfoRe
 	return res, nil
 }
 
-func (ostore *FSSession) Presign(bucket, key string, expire time.Duration) (string, error) {
+func (ostore *FSSession) Presign(name string, expire time.Duration) (string, error) {
 	return "", ErrNotSupported
 }
 

--- a/drivers/gs.go
+++ b/drivers/gs.go
@@ -343,7 +343,7 @@ func (os *gsSession) ReadData(ctx context.Context, name string) (*FileInfoReader
 	return res, nil
 }
 
-func (os *gsSession) Presign(bucket, key string, expire time.Duration) (string, error) {
+func (os *gsSession) Presign(name string, expire time.Duration) (string, error) {
 	return "", ErrNotSupported
 }
 

--- a/drivers/ipfs.go
+++ b/drivers/ipfs.go
@@ -99,7 +99,7 @@ func (session *IpfsSession) ReadData(ctx context.Context, name string) (*FileInf
 	return res, nil
 }
 
-func (session *IpfsSession) Presign(bucket, key string, expire time.Duration) (string, error) {
+func (session *IpfsSession) Presign(name string, expire time.Duration) (string, error) {
 	return "", ErrNotSupported
 }
 

--- a/drivers/local.go
+++ b/drivers/local.go
@@ -192,7 +192,7 @@ func (ostore *MemorySession) GetData(name string) []byte {
 	return nil
 }
 
-func (ostore *MemorySession) Presign(bucket, key string, expire time.Duration) (string, error) {
+func (ostore *MemorySession) Presign(name string, expire time.Duration) (string, error) {
 	return "", ErrNotSupported
 }
 

--- a/drivers/s3.go
+++ b/drivers/s3.go
@@ -489,9 +489,13 @@ func (os *s3Session) IsOwn(url string) bool {
 	return strings.HasPrefix(url, os.host)
 }
 
-func (os *s3Session) Presign(bucket, key string, expire time.Duration) (string, error) {
+func (os *s3Session) Presign(name string, expire time.Duration) (string, error) {
+	key := os.key
+	if name != "" {
+		key = path.Join(key, name)
+	}
 	req, _ := os.s3svc.GetObjectRequest(&s3.GetObjectInput{
-		Bucket: aws.String(bucket),
+		Bucket: aws.String(os.bucket),
 		Key:    aws.String(key),
 	})
 	return req.Presign(expire)

--- a/drivers/session_mock.go
+++ b/drivers/session_mock.go
@@ -74,6 +74,6 @@ func (s *MockOSSession) OS() OSDriver {
 	return nil
 }
 
-func (s *MockOSSession) Presign(bucket, key string, expire time.Duration) (string, error) {
+func (s *MockOSSession) Presign(name string, expire time.Duration) (string, error) {
 	return "", ErrNotSupported
 }

--- a/drivers/w3s.go
+++ b/drivers/w3s.go
@@ -104,7 +104,7 @@ func (session *W3sSession) ReadData(ctx context.Context, name string) (*FileInfo
 	return nil, ErrNotSupported
 }
 
-func (session *W3sSession) Presign(bucket, key string, expire time.Duration) (string, error) {
+func (session *W3sSession) Presign(name string, expire time.Duration) (string, error) {
 	return "", ErrNotSupported
 }
 


### PR DESCRIPTION
I realised that the established design of the OS functions is to make use of the bucket and key that have already been parsed. This also cleans up the calling code by not having to parse out the bucket and key yourself.