### PR TITLE
Hardcode mime type for .m3u8 files

### DIFF
--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -20,8 +20,9 @@ import (
 )
 
 var ext2mime = map[string]string{
-	".ts":  "video/mp2t",
-	".mp4": "video/mp4",
+	".ts":   "video/mp2t",
+	".mp4":  "video/mp4",
+	".m3u8": "application/x-mpegURL",
 }
 
 var ErrFormatMime = fmt.Errorf("unknown file extension")

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -22,7 +22,7 @@ import (
 var ext2mime = map[string]string{
 	".ts":   "video/mp2t",
 	".mp4":  "video/mp4",
-	".m3u8": "application/x-mpegURL",
+	".m3u8": "application/x-mpegurl",
 }
 
 var ErrFormatMime = fmt.Errorf("unknown file extension")

--- a/drivers/drivers_test.go
+++ b/drivers/drivers_test.go
@@ -175,7 +175,7 @@ func TestDescribeDriversJson(t *testing.T) {
 func TestItChoosesTheCorrectContentTypes(t *testing.T) {
 	extType, err := TypeByExtension(".m3u8")
 	require.NoError(t, err)
-	require.Equal(t, "application/x-mpegURL", extType)
+	require.Equal(t, "application/x-mpegurl", extType)
 
 	extType, err = TypeByExtension(".ts")
 	require.NoError(t, err)

--- a/drivers/drivers_test.go
+++ b/drivers/drivers_test.go
@@ -3,12 +3,14 @@ package drivers
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestS3URL(t *testing.T) {
@@ -168,4 +170,22 @@ func TestDescribeDriversJson(t *testing.T) {
 		assert.Equal(h.Description(), driverDescr.Drivers[i].Description)
 		assert.Equal(h.UriSchemes(), driverDescr.Drivers[i].UriSchemes)
 	}
+}
+
+func TestItChoosesTheCorrectContentTypes(t *testing.T) {
+	extType, err := TypeByExtension(".m3u8")
+	require.NoError(t, err)
+	require.Equal(t, "application/x-mpegURL", extType)
+
+	extType, err = TypeByExtension(".ts")
+	require.NoError(t, err)
+	require.Equal(t, "video/mp2t", extType)
+
+	extType, err = TypeByExtension(".mp4")
+	require.NoError(t, err)
+	require.Equal(t, "video/mp4", extType)
+
+	extType, err = TypeByExtension(".json")
+	require.NoError(t, err)
+	require.Equal(t, "application/json", extType)
 }


### PR DESCRIPTION
This was returning `audio/x-mpegurl` for `.m3u8` files on some operating systems.