### PR TITLE
Add content-type to the metadata passed back on reads

### DIFF
--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -63,8 +63,9 @@ type FileInfo struct {
 
 type FileInfoReader struct {
 	FileInfo
-	Metadata map[string]string
-	Body     io.ReadCloser
+	Metadata    map[string]string
+	Body        io.ReadCloser
+	ContentType string
 }
 
 var AvailableDrivers = []OSDriver{

--- a/drivers/gs.go
+++ b/drivers/gs.go
@@ -329,6 +329,7 @@ func (os *gsSession) ReadData(ctx context.Context, name string) (*FileInfoReader
 	res.Size = &attrs.Size
 	res.ETag = attrs.Etag
 	res.LastModified = attrs.Updated
+	res.ContentType = attrs.ContentType
 	if len(attrs.Metadata) > 0 {
 		for k, v := range attrs.Metadata {
 			res.Metadata = make(map[string]string, len(attrs.Metadata))

--- a/drivers/s3.go
+++ b/drivers/s3.go
@@ -348,6 +348,9 @@ func (os *s3Session) ReadData(ctx context.Context, name string) (*FileInfoReader
 	if resp.ETag != nil {
 		res.ETag = *resp.ETag
 	}
+	if resp.ContentType != nil {
+		res.ContentType = *resp.ContentType
+	}
 	res.Name = name
 	res.Size = resp.ContentLength
 	if len(resp.Metadata) > 0 {


### PR DESCRIPTION
For the access-control feature this will enable us to proxy this back in the headers for playback requests