### PR TITLE
Add content-range to the metadata passed back on reads

### DIFF
--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -63,9 +63,10 @@ type FileInfo struct {
 
 type FileInfoReader struct {
 	FileInfo
-	Metadata    map[string]string
-	Body        io.ReadCloser
-	ContentType string
+	Metadata     map[string]string
+	Body         io.ReadCloser
+	ContentType  string
+	ContentRange string
 }
 
 var AvailableDrivers = []OSDriver{

--- a/drivers/s3.go
+++ b/drivers/s3.go
@@ -358,6 +358,9 @@ func (os *s3Session) ReadDataRange(ctx context.Context, name, byteRange string) 
 	if resp.ContentType != nil {
 		res.ContentType = *resp.ContentType
 	}
+	if resp.ContentRange != nil {
+		res.ContentRange = *resp.ContentRange
+	}
 	res.Name = name
 	res.Size = resp.ContentLength
 	if len(resp.Metadata) > 0 {


### PR DESCRIPTION
This is required for MP4 playback in Safari