### PR TITLE
Fix S3 support for Filebase

### DIFF
--- a/drivers/drivers_test.go
+++ b/drivers/drivers_test.go
@@ -89,13 +89,14 @@ func TestCustomS3URLWithRegion(t *testing.T) {
 
 func TestCustomS3RegionParser(t *testing.T) {
 	cases := [][]string{
-		{"http://one:9000", "one"},
-		{"http://one.two:9000", "one"},
-		{"http://one.two.three:9000", "two"},
+		{"http://one:9000", "us-east-1"},
+		{"http://one.two:9000", "us-east-1"},
+		{"http://one.two.three:9000", "us-east-1"},
 		{"http://one.two.three.four:9000", "two"},
 		{"http://one.two.three.four.five:9000", "two"},
 		{"http://s3.eu-central-2.wasabisys.com", "eu-central-2"},
 		{"http://s3.us-east-2.amazonaws.com", "us-east-2"},
+		{"https://s3.filebase.com", "us-east-1"},
 	}
 	assert := assert.New(t)
 	for _, pair := range cases {

--- a/drivers/drivers_test.go
+++ b/drivers/drivers_test.go
@@ -71,7 +71,7 @@ func TestCustomS3URL(t *testing.T) {
 	assert.Equal("bucket-name", s3.bucket)
 	assert.Equal("user", s3.awsAccessKeyID)
 	assert.Equal("password", s3.awsSecretAccessKey)
-	assert.Equal("example", s3.region)
+	assert.Equal("us-east-1", s3.region)
 }
 
 func TestCustomS3URLWithRegion(t *testing.T) {
@@ -82,7 +82,7 @@ func TestCustomS3URLWithRegion(t *testing.T) {
 	assert.Equal(nil, err)
 	assert.Equal("http://example.com:9000", s3.host)
 	assert.Equal("bucket-name", s3.bucket)
-	assert.Equal("example", s3.region)
+	assert.Equal("us-east-1", s3.region)
 	assert.Equal("user", s3.awsAccessKeyID)
 	assert.Equal("password", s3.awsSecretAccessKey)
 }

--- a/drivers/s3.go
+++ b/drivers/s3.go
@@ -41,7 +41,7 @@ const (
 	// the future for optimized support of other storage providers.
 	uploaderPartSize = 63 * 1024 * 1024
 	// default region parameter if we can't derive one from the url
-	defaultIgnoredRegion = "ignored"
+	defaultIgnoredRegion = "us-east-1"
 )
 
 var _ OSSession = (*s3Session)(nil)
@@ -102,13 +102,10 @@ func customS3Region(host string) string {
 	}
 	hostname := u.Hostname()
 	parts := strings.Split(hostname, ".")
-	if len(parts) == 1 {
-		return hostname
+	if len(parts) >= 4 {
+		return parts[1]
 	}
-	if len(parts) == 2 {
-		return parts[0]
-	}
-	return parts[1]
+	return defaultIgnoredRegion
 }
 
 func newS3Session(info *S3OSInfo) OSSession {

--- a/drivers/s3_test.go
+++ b/drivers/s3_test.go
@@ -155,6 +155,28 @@ func TestStorjS3Read(t *testing.T) {
 	}
 }
 
+func TestFilebaseS3Read(t *testing.T) {
+	s3key := os.Getenv("FILEBASE_S3_KEY")
+	s3secret := os.Getenv("FILEBASE_S3_SECRET")
+	s3bucket := os.Getenv("FILEBASE_S3_BUCKET")
+	s3Path := os.Getenv("FILEBASE_S3_PATH")
+	require := require.New(t)
+	if s3key != "" && s3secret != "" && s3bucket != "" && s3Path != "" {
+		fullUrl := fmt.Sprintf("s3+https://%s:%s@s3.filebase.com/%s", s3key, s3secret, s3bucket)
+		os, err := ParseOSURL(fullUrl, true)
+		require.NoError(err)
+		session := os.NewSession("")
+		data, err := session.ReadData(context.Background(), s3Path)
+		require.NoError(err)
+		osBuf := new(bytes.Buffer)
+		osBuf.ReadFrom(data.Body)
+		osData := osBuf.Bytes()
+		require.True(len(osData) > 0)
+	} else {
+		t.Skip("No S3 credentials, test skipped")
+	}
+}
+
 func TestWasabiS3Upload(t *testing.T) {
 	s3key := os.Getenv("WASABI_S3_KEY")
 	s3secret := os.Getenv("WASABI_S3_SECRET")


### PR DESCRIPTION
Filebase requires setting "region" to "us-east-1" in the AWS Client configuration. In general, I think we should set `us-east-1` by default, since it's a default parameter in the AWS CLI.