### PR TITLE
Ability to override content type on upload

### DIFF
--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -72,6 +72,7 @@ type FileInfoReader struct {
 type FileProperties struct {
 	Metadata     map[string]string
 	CacheControl string
+	ContentType  string
 }
 
 var AvailableDrivers = []OSDriver{

--- a/drivers/s3.go
+++ b/drivers/s3.go
@@ -385,6 +385,9 @@ func (os *s3Session) saveDataPut(ctx context.Context, name string, data io.Reade
 	if err != nil {
 		return "", err
 	}
+	if fields != nil && fields.ContentType != "" {
+		contentType = fields.ContentType
+	}
 
 	uploader := s3manager.NewUploader(os.s3sess, func(u *s3manager.Uploader) {
 		u.Concurrency = uploaderConcurrency


### PR DESCRIPTION
VTT files were just being detected as `text/plain` so need the ability to override this.