### PR TITLE
drivers: Implement a consistent error for "not exist"

### DIFF
--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -30,8 +30,11 @@ var ErrFormatMime = fmt.Errorf("unknown file extension")
 // ErrNoNextPage indicates that there is no next page in ListFiles
 var ErrNoNextPage = fmt.Errorf("no next page")
 
-// ErrNotSupported indicated that the functionality is not supported by the given driver
+// ErrNotSupported indicates that the functionality is not supported by the given driver
 var ErrNotSupported = fmt.Errorf("not supported")
+
+// ErrNotExist indicates that the file being fetched does not exist
+var ErrNotExist = fmt.Errorf("the specified file does not exist")
 
 // NodeStorage is current node's primary driver
 var NodeStorage OSDriver

--- a/drivers/fs.go
+++ b/drivers/fs.go
@@ -138,10 +138,15 @@ func (ostore *FSSession) ReadData(ctx context.Context, name string) (*FileInfoRe
 	}
 	fullPath := path.Join(prefix, name)
 	file, err := os.Open(fullPath)
-	if err != nil {
+	if os.IsNotExist(err) {
+		return nil, ErrNotExist
+	} else if err != nil {
 		return nil, err
 	}
 	stat, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
 	size := stat.Size()
 	res := &FileInfoReader{
 		FileInfo: FileInfo{

--- a/drivers/gs.go
+++ b/drivers/gs.go
@@ -164,7 +164,7 @@ func (os *gsSession) createClient() error {
 
 func (os *gsSession) DeleteFile(ctx context.Context, name string) error {
 	if !os.useFullAPI {
-		return errors.New("delete not supported for non full api")
+		return ErrNotSupported
 	}
 	if os.client == nil {
 		if err := os.createClient(); err != nil {

--- a/drivers/gs.go
+++ b/drivers/gs.go
@@ -325,7 +325,9 @@ func (os *gsSession) ReadData(ctx context.Context, name string) (*FileInfoReader
 
 	objh := os.client.Bucket(os.bucket).Object(name)
 	attrs, err := objh.Attrs(ctx)
-	if err != nil {
+	if errors.Is(err, storage.ErrObjectNotExist) || errors.Is(err, storage.ErrBucketNotExist) {
+		return nil, ErrNotExist
+	} else if err != nil {
 		return nil, err
 	}
 	res := &FileInfoReader{}
@@ -341,7 +343,9 @@ func (os *gsSession) ReadData(ctx context.Context, name string) (*FileInfoReader
 		}
 	}
 	rc, err := objh.NewReader(ctx)
-	if err != nil {
+	if errors.Is(err, storage.ErrObjectNotExist) || errors.Is(err, storage.ErrBucketNotExist) {
+		return nil, ErrNotExist
+	} else if err != nil {
 		return nil, err
 	}
 	res.Body = rc

--- a/drivers/ipfs.go
+++ b/drivers/ipfs.go
@@ -2,6 +2,7 @@ package drivers
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"path"
@@ -90,6 +91,10 @@ func (session *IpfsSession) ReadData(ctx context.Context, name string) (*FileInf
 	resp, err := http.Get("https://gateway.pinata.cloud/ipfs/" + fullPath)
 	if err != nil {
 		return nil, err
+	} else if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotExist
+	} else if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("failed to read IPFS file: %d %s", resp.StatusCode, resp.Status)
 	}
 	res := &FileInfoReader{
 		FileInfo: FileInfo{

--- a/drivers/local.go
+++ b/drivers/local.go
@@ -3,7 +3,6 @@ package drivers
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -147,7 +146,7 @@ func (ostore *MemorySession) ListFiles(ctx context.Context, prefix, delim string
 func (ostore *MemorySession) ReadData(ctx context.Context, name string) (*FileInfoReader, error) {
 	data := ostore.GetData(name)
 	if data == nil {
-		return nil, errors.New("Not found")
+		return nil, ErrNotExist
 	}
 	size := int64(len(data))
 	res := &FileInfoReader{

--- a/drivers/s3.go
+++ b/drivers/s3.go
@@ -8,9 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
-	"errors"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws/request"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -18,6 +16,8 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	"github.com/aws/aws-sdk-go/aws/request"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -319,7 +319,7 @@ func (os *s3Session) ListFiles(ctx context.Context, prefix, delim string) (PageI
 		return pi, nil
 	}
 
-	return nil, fmt.Errorf("Not implemented")
+	return nil, ErrNotSupported
 }
 
 func (os *s3Session) ReadData(ctx context.Context, name string) (*FileInfoReader, error) {
@@ -328,7 +328,7 @@ func (os *s3Session) ReadData(ctx context.Context, name string) (*FileInfoReader
 
 func (os *s3Session) ReadDataRange(ctx context.Context, name, byteRange string) (*FileInfoReader, error) {
 	if os.s3svc == nil {
-		return nil, fmt.Errorf("Not implemented")
+		return nil, ErrNotSupported
 	}
 	// TODO: Remove this compat once legacy clients stop sending the full path for reading
 	if os.key != "" && !strings.HasPrefix(name, os.key+"/") {
@@ -423,7 +423,7 @@ func (os *s3Session) saveDataPut(ctx context.Context, name string, data io.Reade
 
 func (os *s3Session) DeleteFile(ctx context.Context, name string) error {
 	if os.s3svc == nil {
-		return errors.New("delete not supported for non full api")
+		return ErrNotSupported
 	}
 	params := &s3.DeleteObjectInput{
 		Bucket: aws.String(os.bucket),


### PR DESCRIPTION
On the catalyst-api changes to support a backup storage, we will need to handle 404s more
gracefully to avoid retrying for a long time reading from a storage that just doesn't have the file.

This is especially relevant in the manifest fetching code, which will always need to fetch the file in
both primary and backup storages. We don't want to wait for all retries on the backup storage when
the manifest only exists on the primary (most of the time).